### PR TITLE
別環境だとDev Containerが立ち上がらない問題に対処した

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 1. このリポジトリをクローンします。
 2. VS Codeを開きます。
-3. Remote-Containers拡張機能をインストールします。
+3. [Dev ContainersというVS Codeの拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)をインストールします。
 4. 左下の「><」をクリックして、コマンドパレットを開きます。
 5. `Remote-Containers: Reopen in Container`を選択します。
 6. コンテナの起動と同時に新しいウィンドウが開き、画面左下に「開発コンテナ: python @ desktop-linux」と表示されているのを確認します。

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@
 
 ## はじめての使い方
 
+1. [Docker Desktop](https://www.docker.com/ja-jp/products/docker-desktop/)をインストールし、起動します。
 1. このリポジトリをクローンします。
-2. VS Codeを開きます。
-3. [Dev ContainersというVS Codeの拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)をインストールします。
-4. 左下の「><」をクリックして、コマンドパレットを開きます。
-5. `Remote-Containers: Reopen in Container`を選択します。
-6. コンテナの起動と同時に新しいウィンドウが開き、画面左下に「開発コンテナ: python @ desktop-linux」と表示されているのを確認します。
-7. ターミナルを開いて、`(workspace) root@9dd39b93510f:/workspace#`のように表示されていることを確認します。
-8. `python --version`を実行してPythonのバージョンが`Python 3.12.8`と表示されることを確認します。
-9. `streamlit run app/app.py`を実行して、アプリが起動したら成功です。やったね！
+1. VS Codeを開きます。
+1. [Dev ContainersというVS Codeの拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)をインストールします。
+1. 左下の「><」をクリックして、コマンドパレットを開きます。
+1. `Remote-Containers: Reopen in Container`を選択します。
+1. コンテナの起動と同時に新しいウィンドウが開き、画面左下に「開発コンテナ: python @ desktop-linux」と表示されているのを確認します。
+1. ターミナルを開いて、`(workspace) root@9dd39b93510f:/workspace#`のように表示されていることを確認します。
+1. `python --version`を実行してPythonのバージョンが`Python 3.12.8`と表示されることを確認します。
+1. `streamlit run app/app.py`を実行して、アプリが起動したら成功です。やったね！
 
 ## その他の使い方
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@
 ## はじめての使い方
 
 1. [Docker Desktop](https://www.docker.com/ja-jp/products/docker-desktop/)をインストールし、起動します。
+1. [仮のデータセット](https://drive.google.com/drive/folders/1SemmXN9oCed0N0fkdnYHC0rVgbMH6KLE)をダウンロードし、解凍しておきます。
 1. このリポジトリをクローンします。
 1. VS Codeを開きます。
+1. `.devcontainer/.env.example`というファイルをコピーして、`.devcontainer/.env`というファイルを作成します（注意：このファイルにはユーザーの環境依存な情報を書き込むことになるのでgitでコミットしないで下さい。デフォルトでgitのトラッキングから外しているので特に何もしなくて大丈夫です）。
+1. `.devcontainer/.env`の`LOCAL_DATASETS_PATH`をデータセットが保存されているディレクトリに変更します。例えば、先ほどダウンロードしたデータセットが`/path/to/your/local/datasets`に保存されている場合、以下のように書き換えます。
+
+    ```bash
+    LOCAL_DATASETS_PATH=/path/to/your/local/datasets
+    ```
+
 1. [Dev ContainersというVS Codeの拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)をインストールします。
 1. 左下の「><」をクリックして、コマンドパレットを開きます。
 1. `Remote-Containers: Reopen in Container`を選択します。


### PR DESCRIPTION
READMEに環境設定に必要となる以下の情報を追加した

- `.devcontainer/.env`の設定方法についての記述を追加
- 仮のデータセットのリンク＆ダウンロード手順について明記
- docker desktopをインストールすることを明記

Close #5 